### PR TITLE
READMEのヘッダ画像を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- ![](https://github.com/tokyo-metropolitan-gov/covid19/workflows/production%20deploy/badge.svg) -->
 
-[![福井県 新型コロナウイルス感染症対策サイト（非公式）](https://user-images.githubusercontent.com/1301149/75629392-1d19d900-5c25-11ea-843d-2d4376e3a560.png)](https://covid19-fukui.com/)
+[![福井県 新型コロナウイルス感染症対策サイト（非公式）](/static/ogp.png)](https://covid19-fukui.com/)
 
 ## 貢献の仕方
 pull requestをお送りください。


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2 

## ⛏ 変更内容 / Details of Changes
- `README.md`のヘッダ画像を`/static/ogp.png`(福井県用ヘッダ)に変更

## 📸 スクリーンショット / Screenshots
### Before
![before](https://user-images.githubusercontent.com/17569894/77327725-f865dc80-6d5e-11ea-9362-4af84eaf1e52.png)

### After
![after](https://user-images.githubusercontent.com/17569894/77327812-0ae01600-6d5f-11ea-9489-d2c9c186c8d6.png)
