### PR TITLE
福井県内, 国内のお知らせ一覧専用ページを作成

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -124,6 +124,17 @@ export default Vue.extend({
           divider: true
         },
         {
+          icon: 'mdi-information',
+          title: this.$t('福井県内のお知らせ一覧'),
+          link: this.localePath('/news')
+        },
+        {
+          icon: 'mdi-information',
+          title: this.$t('国内のお知らせ一覧'),
+          link: this.localePath('/japan-news'),
+          divider: true
+        },
+        {
           icon: 'mdi-account-multiple',
           title: this.$t('福井県民の皆様へ'),
           link: 'https://www.pref.fukui.lg.jp/doc/kenkou/kansensyo-yobousessyu/corona.html#'

--- a/pages/japan-news.vue
+++ b/pages/japan-news.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="JapanNewsList">
+    <page-header class="mb-3">
+      <v-icon size="24" class="JapanNewsList-heading-icon">
+        mdi-information
+      </v-icon>
+      {{ $t('国内のお知らせ一覧') }}
+    </page-header>
+    <ul class="JapanNewsList-list">
+      <li v-for="(item, i) in items" class="JapanNewsList-list-item">
+        <a
+          class="JapanNewsList-list-item-anchor"
+          :href="item.url"
+          target="_blank"
+          rel="noopener"
+        >
+          <time
+            class="JapanNewsList-list-item-anchor-time px-2"
+            :datetime="formattedDate(item.date)"
+          >
+            {{ item.date }}
+          </time>
+          <p class="JapanNewsList-list-item-anchor-link">
+            {{ item.text }}
+            <v-icon
+              v-if="!isInternalLink(item.url)"
+              class="JapanNewsList-item-ExternalLinkIcon"
+              size="12"
+            >
+              mdi-open-in-new
+            </v-icon>
+          </p>
+        </a>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
+import PageHeader from '@/components/PageHeader.vue'
+import StaticCard from '@/components/StaticCard.vue'
+import News from '@/data/japan.json'
+import { convertDateToISO8601Format } from '@/utils/formatDate.ts'
+
+export default Vue.extend({
+  components: {
+    PageHeader,
+    StaticCard
+  },
+  head(): MetaInfo {
+    return {
+      title: this.$t('国内のお知らせ一覧') as string
+    }
+  }, 
+  computed: {
+      items() {
+          return News.japanItems
+      }
+  },
+  methods: {
+    isInternalLink(path: string): boolean {
+      return !/^https?:\/\//.test(path)
+    },
+    formattedDate(dateString: string) {
+      return convertDateToISO8601Format(dateString)
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.JapanNewsList {
+  @include card-container();
+
+  padding: 10px;
+  margin-bottom: 20px;
+}
+
+.JapanNewsList-heading {
+  display: flex;
+  align-items: center;
+
+  @include card-h2();
+
+  margin-bottom: 12px;
+  color: $gray-2;
+  margin-left: 12px;
+
+  &-icon {
+    margin: 10px;
+  }
+}
+
+.JapanNewsList .JapanNewsList-list {
+  padding-left: 0;
+  list-style-type: none;
+
+  &-item {
+    &-anchor {
+      display: inline-block;
+      text-decoration: none;
+      margin: 5px;
+      font-size: 16px;
+
+      @include lessThan($medium) {
+        display: flex;
+        flex-wrap: wrap;
+      }
+
+      &-time {
+        flex: 0 0 90px;
+
+        @include lessThan($medium) {
+          flex: 0 0 100%;
+        }
+
+        color: $gray-1;
+      }
+
+      &-link {
+        flex: 0 1 auto;
+        display: inline;
+
+        @include text-link();
+
+        @include lessThan($medium) {
+          padding-left: 8px;
+        }
+      }
+
+      &-ExternalLinkIcon {
+        margin-left: 2px;
+        color: $gray-3 !important;
+      }
+    }
+  }
+}
+</style>

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="NewsList">
+    <page-header class="mb-3">
+      <v-icon size="24" class="NewsList-heading-icon">
+        mdi-information
+      </v-icon>
+      {{ $t('福井県内のお知らせ一覧') }}
+    </page-header>
+    <ul class="NewsList-list">
+      <li v-for="(item, i) in items" class="NewsList-list-item">
+        <a
+          class="NewsList-list-item-anchor"
+          :href="item.url"
+          target="_blank"
+          rel="noopener"
+        >
+          <time
+            class="NewsList-list-item-anchor-time px-2"
+            :datetime="formattedDate(item.date)"
+          >
+            {{ item.date }}
+          </time>
+          <p class="NewsList-list-item-anchor-link">
+            {{ item.text }}
+            <v-icon
+              v-if="!isInternalLink(item.url)"
+              class="NewsList-item-ExternalLinkIcon"
+              size="12"
+            >
+              mdi-open-in-new
+            </v-icon>
+          </p>
+        </a>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
+import PageHeader from '@/components/PageHeader.vue'
+import StaticCard from '@/components/StaticCard.vue'
+import News from '@/data/news.json'
+import { convertDateToISO8601Format } from '@/utils/formatDate.ts'
+
+export default Vue.extend({
+  components: {
+    PageHeader,
+    StaticCard
+  },
+  head(): MetaInfo {
+    return {
+      title: this.$t('福井県内のお知らせ一覧') as string
+    }
+  }, 
+  computed: {
+      items() {
+          return News.newsItems
+      }
+  },
+  methods: {
+    isInternalLink(path: string): boolean {
+      return !/^https?:\/\//.test(path)
+    },
+    formattedDate(dateString: string) {
+      return convertDateToISO8601Format(dateString)
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.NewsList {
+  @include card-container();
+
+  padding: 10px;
+  margin-bottom: 20px;
+}
+
+.NewsList-heading {
+  display: flex;
+  align-items: center;
+
+  @include card-h2();
+
+  margin-bottom: 12px;
+  color: $gray-2;
+  margin-left: 12px;
+
+  &-icon {
+    margin: 10px;
+  }
+}
+
+.NewsList .NewsList-list {
+  padding-left: 0;
+  list-style-type: none;
+
+  &-item {
+    &-anchor {
+      display: inline-block;
+      text-decoration: none;
+      margin: 5px;
+      font-size: 16px;
+
+      @include lessThan($medium) {
+        display: flex;
+        flex-wrap: wrap;
+      }
+
+      &-time {
+        flex: 0 0 90px;
+
+        @include lessThan($medium) {
+          flex: 0 0 100%;
+        }
+
+        color: $gray-1;
+      }
+
+      &-link {
+        flex: 0 1 auto;
+        display: inline; 
+        
+        @include text-link();
+
+        @include lessThan($medium) {
+          padding-left: 8px;
+        }
+      }
+
+      &-ExternalLinkIcon {
+        margin-left: 2px;
+        color: $gray-3 !important;
+      }
+    }
+  }
+}
+</style>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #18 

## ⛏ 変更内容 / Details of Changes
- 福井県内, 国内のお知らせだけを表示する専用のページを作成

## 📸 スクリーンショット / Screenshots
- 福井県内
<img width="921" alt="スクリーンショット 2020-03-28 2 25 54" src="https://user-images.githubusercontent.com/11400588/77783082-97f6d800-709b-11ea-889f-f5fbfca5cbf7.png">

- 国内
<img width="811" alt="スクリーンショット 2020-03-28 2 26 02" src="https://user-images.githubusercontent.com/11400588/77783115-a34a0380-709b-11ea-911b-32e946964594.png">
