### PR TITLE
PCR検査実施件数のカードがスマホで正常に動作していないので一時的に非表示処理

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,7 @@
       <confirmed-cases-details-card />
       <confirmed-cases-attributes-card />
       <inspection-persons-number-card />
-      <pcr-inspection-reports-number-card />
+      <!-- <pcr-inspection-reports-number-card /> -->
       <hospital-beds-number-card />
     </v-row>
   </div>


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #11 

## ⛏ 変更内容 / Details of Changes
- 一時的にPCR検査実施件数に関するグラフを本番環境から非表示にした
