### PR TITLE
YouTube API関係が整理できるまでは、常時表示を中止, LIVEの都度更新で臨時対応

### DIFF
--- a/components/cards/YoutubeCard.vue
+++ b/components/cards/YoutubeCard.vue
@@ -4,7 +4,7 @@
       <v-card-title>福井県のYouTube（LIVE）</v-card-title>
       <!-- <v-card-subtitle>公開日時: {{ publishedAt }}</v-card-subtitle> -->
       <v-card-text>
-        <iframe style="width=100%;" height="315" src="https://www.youtube.com/embed/WaypSgzvlU4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <!-- <iframe style="width=100%;" height="315" src="https://www.youtube.com/embed/WaypSgzvlU4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> -->
       </v-card-text>
     </v-card>
   </v-col>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,7 +23,7 @@
       :btn-text="$t('福井県公式サイトへ')"
     />
     <v-row class="DataBlock">
-      <youtube-card />
+      <!-- <youtube-card /> -->
       <confirmed-cases-details-card />
       <confirmed-cases-attributes-card />
       <inspection-persons-number-card />


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #28 

## ⛏ 変更内容 / Details of Changes
- YouTube動画を表示しておくカードを一時的に非活性化。臨時記者会見が行われる時に埋め込みリンクを更新することで一時的に対応する。
