### PR TITLE
検査実施人数カードのsTextの表記を変更

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -178,17 +178,19 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       if (this.dataKind === 'transition') {
         return {
           lText: this.sum(this.pickLastNumber(this.chartData)).toLocaleString(),
-          sText: `${this.$t('{date}の合計', {
-            date: this.labels[this.labels.length - 1]
-          })}`,
+          sText: '今週の合計',
+          // sText: `${this.$t('{date}の合計', {
+          //   date: this.labels[this.labels.length - 1]
+          // })}`,
           unit: this.unit
         }
       }
       return {
         lText: this.sum(this.cumulativeSum(this.chartData)).toLocaleString(),
-        sText: `${this.$t('{date}の全体累計', {
-          date: this.labels[this.labels.length - 1]
-        })}`,
+        sText: '全体の累計',
+        // sText: `${this.$t('{date}の全体累計', {
+        //   date: this.labels[this.labels.length - 1]
+        // })}`,
         unit: this.unit
       }
     },


### PR DESCRIPTION
日付情報を使用しないようにした

## 👏 解決する issue / Resolved Issues
- close #36 

## ⛏ 変更内容 / Details of Changes
- `components/TimeStackedBarChart.vue`の週別及び類型のsTextの表記を`date`を用いない表記に変更
