### PR TITLE
陽性患者数カードのデータと更新日時を同じファイルから取得

### DIFF
--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -5,7 +5,7 @@
       :title-id="'number-of-confirmed-cases'"
       :chart-id="'time-bar-chart-patients'"
       :chart-data="patientsGraph"
-      :date="Patients.date"
+      :date="patientsSummaryDate"
       :unit="$t('人')"
       :url="'https://www.pref.fukui.lg.jp/doc/kenkou/kansensyo-yobousessyu/corona.html'"
     />
@@ -14,7 +14,6 @@
   
 <script>
 import PatientsSummary from '@/data/patients_summary.json'
-import Patients from '@/data/patients.json'
 import formatGraph from '@/utils/formatGraph'
 import TimeBarChart from '@/components/TimeBarChart.vue'
 
@@ -25,9 +24,9 @@ export default {
   data() {
     // 感染者数グラフ
     const patientsGraph = formatGraph(PatientsSummary.data)
-
+    const patientsSummaryDate = new Date(PatientsSummary.date).toLocaleString()
     const data = {
-      Patients,
+      patientsSummaryDate,
       patientsGraph
     }
     return data


### PR DESCRIPTION

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #65 

## 📝 関連する issue / Related Issues
- #57 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- グラフデータは patients_summary.json から、更新日時は patients.json から取得していた
- いずれもdata/patients_summary.jsonから取得するよう変更 
