### PR TITLE
日付を修正

### DIFF
--- a/components/BreakingNews.vue
+++ b/components/BreakingNews.vue
@@ -11,7 +11,7 @@
       <h3 class="breaking-content" />
       <li class="BreakingNews-list-item">
         <time class="BreakingNews-list-item-anchor-time px-2">
-          2020/04/01
+          2020/04/02
         </time>
         <p class="BreakingNews-list-item-anchor-link">
           福井県内で22例目~30例目となる新型コロナウイルス感染者が確認されました。詳細は


### PR DESCRIPTION
4月2日の情報の日付を4月1日と書いていた

## 👏 解決する issue / Resolved Issues
- close #73 

## 📝 関連する issue / Related Issues
- #68 
- #70 

## ⛏ 変更内容 / Details of Changes
- 速報カードの日付を修正
