### PR TITLE
陽性患者数のグラフが表示されないバグを修正

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@ Fukui Covid-19 response site contributors
 | --- | --- | --- | --- | --- |
 | [Hiroki Nomura](https://www.nomunomu0504.work/portfolio) | [@nomunomu0504](https://github.com/nomunomu0504) | [@nomunomu0504](https://twitter.com/nomunomu0504) | Project facilitation | とにかく地元に貢献できればOKの精神 |
 | [FooQoo](https://fooqoo.github.io/) | [@FooQoo](https://github.com/fooqoo) | [@FooQoo56](https://twitter.com/FooQoo56) | Coding, Review | 元福井高専生で現在都内IT企業に所属してます。少しでも地元に貢献できればと参加いたしました |
+| hIDDEN_xv | [@hiddenxv](https://github.com/hiddenxv) | [@hIDDEN_xv](https://twitter.com/hIDDEN_xv) | Coding | 修正・機能追加などなど、何かあれば相談ください。 |
 
 
 ご協力に感謝です！！！

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -45,7 +45,7 @@ import PatientsSummary from '@/data/patients_summary.json'
 // import ChiyodaData from '@/data/13101_daily_visitors.json'
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 // import TestedCasesDetailsCard from '@/components/cards/TestedCasesDetailsCard.vue'
-// import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
+import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
 import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
 // import TestedNumåberCard from '@/components/cards/TestedNumberCard.vue'
 import InspectionPersonsNumberCard from '@/components/cards/InspectionPersonsNumberCard.vue'
@@ -60,7 +60,7 @@ export default {
   components: {
     ConfirmedCasesDetailsCard,
     // TestedCasesDetailsCard,
-    // ConfirmedCasesNumberCard,
+    ConfirmedCasesNumberCard,
     ConfirmedCasesAttributesCard,
     // TestedNumberCard,
     InspectionPersonsNumberCard,


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #85 

## ⛏ 変更内容 / Details of Changes
- 陽性患者数に関する単体のグラフが正常に表示されないバグを修正
