### PR TITLE
#96 トップページに福井新聞社のRSSフィードを表示

### DIFF
--- a/components/BreakingNews.vue
+++ b/components/BreakingNews.vue
@@ -4,12 +4,11 @@
       <v-icon size="24" class="BreakingNews-heading-icon">
         mdi-information
       </v-icon>
-      {{ $t('速報（福井県内）') }}
+      {{ $t('速報') }}
       <a class="WhatsNew-heading-link" :href="this.localePath('/news')"
-        >一覧はこちらから</a
+        >過去のお知らせはこちら</a
       >
     </h2>
-
     <ul class="BreakingNews-list">
       <h3 class="breaking-content" />
       <li v-for="(item, i) in items" :key="i" class="BreakingNews-list-item">

--- a/components/BreakingNews.vue
+++ b/components/BreakingNews.vue
@@ -4,16 +4,20 @@
       <v-icon size="24" class="BreakingNews-heading-icon">
         mdi-information
       </v-icon>
-      {{ $t('速報') }}
+      {{ $t('速報（福井県内）') }}
+      <a class="WhatsNew-heading-link" :href="this.localePath('/news')"
+        >一覧はこちらから</a
+      >
     </h2>
 
     <ul class="BreakingNews-list">
       <h3 class="breaking-content" />
       <li v-for="(item, i) in items" :key="i" class="BreakingNews-list-item">
-        <time class="BreakingNews-list-item-anchor-time px-2" v-html="item.date">
-        </time>
-        <p class="BreakingNews-list-item-anchor-link" v-html="item.text">
-        </p>
+        <time
+          class="BreakingNews-list-item-anchor-time px-2"
+          v-html="item.date"
+        />
+        <p class="BreakingNews-list-item-anchor-link" v-html="item.text" />
       </li>
     </ul>
   </div>

--- a/components/BreakingNews.vue
+++ b/components/BreakingNews.vue
@@ -5,7 +5,7 @@
         mdi-information
       </v-icon>
       {{ $t('速報') }}
-      <a class="WhatsNew-heading-link" :href="this.localePath('/news')"
+      <a class="BreakingNews-heading-link" :href="this.localePath('/news')"
         >過去のお知らせはこちら</a
       >
     </h2>
@@ -64,6 +64,16 @@ export default Vue.extend({
 
   &-icon {
     margin: 10px;
+  }
+
+  &-link {
+    flex: 0 1 auto;
+
+    @include text-link();
+
+    @include lessThan($medium) {
+      padding-left: 8px;
+    }
   }
 }
 

--- a/components/BreakingNews.vue
+++ b/components/BreakingNews.vue
@@ -68,12 +68,9 @@ export default Vue.extend({
 
   &-link {
     flex: 0 1 auto;
+    padding-left: 8px;
 
     @include text-link();
-
-    @include lessThan($medium) {
-      padding-left: 8px;
-    }
   }
 }
 

--- a/components/FukuiNews.vue
+++ b/components/FukuiNews.vue
@@ -34,9 +34,6 @@
               mdi-open-in-new
             </v-icon>
           </span>
-          <p class="WhatsNew-list-item-anchor-time px-2">
-            {{ item.desc }}
-          </p>
         </a>
       </li>
     </ul>

--- a/components/FukuiNews.vue
+++ b/components/FukuiNews.vue
@@ -4,7 +4,7 @@
       <v-icon size="24" class="WhatsNew-heading-icon">
         mdi-information
       </v-icon>
-      {{ $t('福井県からのお知らせ（RSS)') }}
+      {{ $t('福井県からのお知らせ（RSS）') }}
     </h3>
     <ul class="WhatsNew-list">
       <li

--- a/components/FukuiPaperNews.vue
+++ b/components/FukuiPaperNews.vue
@@ -4,7 +4,7 @@
       <v-icon size="24" class="WhatsNew-heading-icon">
         mdi-information
       </v-icon>
-      {{ $t('福井県からのお知らせ（RSS)') }}
+      {{ $t('福井新聞者の速報（RSS)') }}
     </h3>
     <ul class="WhatsNew-list">
       <li
@@ -34,9 +34,6 @@
               mdi-open-in-new
             </v-icon>
           </span>
-          <p class="WhatsNew-list-item-anchor-time px-2">
-            {{ item.desc }}
-          </p>
         </a>
       </li>
     </ul>
@@ -58,20 +55,24 @@ export default Vue.extend({
   },
   async mounted() {
     try {
-      const res = await axios.get('/pref/news.xml')
+      const res = await axios.get('/fukuishimbun/list/feed/rss')
       const xml = res.data
       parseString(xml, (_, xmlres: any) => {
-        this.info = xmlres['rdf:RDF'].item
+        this.info = xmlres.rss.channel[0].item
           .map((i: any) => {
             return {
               title: i.title[0],
               link: i.link[0],
-              desc: i.description[0],
-              datetime: moment(i['dc:date'][0]).format('YYYY/MM/DD HH:mm')
+              datetime: moment(i.pubDate[0]).format('YYYY/MM/DD HH:mm')
             }
           })
           .filter((i: any) => {
-            return i.title.includes('コロナ')
+            return (
+              i.title.includes('感染') ||
+              i.title.includes('コロナ') ||
+              i.title.includes('休業') ||
+              i.title.includes('休館')
+            )
           })
       })
     } catch (error) {

--- a/components/FukuiPaperNews.vue
+++ b/components/FukuiPaperNews.vue
@@ -4,7 +4,7 @@
       <v-icon size="24" class="WhatsNew-heading-icon">
         mdi-information
       </v-icon>
-      {{ $t('福井新聞者の速報（RSS)') }}
+      {{ $t('福井新聞者の速報（RSS）') }}
     </h3>
     <ul class="WhatsNew-list">
       <li

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -215,10 +215,16 @@ const config: Configuration = {
     routes: []
   },
   proxy: {
-    '/api': {
+    '/pref': {
       target: 'https://www.pref.fukui.lg.jp',
       pathRewrite: {
-        '^/api': '/'
+        '^/pref': '/'
+      }
+    },
+    '/fukuishimbun': {
+      target: 'https://www.fukuishimbun.co.jp',
+      pathRewrite: {
+        '^/fukuishimbun': '/'
       }
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,6 +13,7 @@
       </div>
     </div>
     <breaking-news class="mb-4" :items="BreakingItems" />
+    <fukui-paper-news class="mb-4" />
     <fukui-news class="mb-4" />
     <whats-new class="mb-4" :items="newsItems" />
     <whats-new-japan class="mb-4" :items="japanItems" />
@@ -44,6 +45,7 @@ import PageHeader from '@/components/PageHeader.vue'
 import BreakingNews from '@/components/BreakingNews.vue'
 import WhatsNew from '@/components/WhatsNew.vue'
 import WhatsNewJapan from '@/components/WhatsNewJapan.vue'
+import FukuiPaperNews from '@/components/FukuiPaperNews.vue'
 import FukuiNews from '@/components/FukuiNews.vue'
 import StaticInfo from '@/components/StaticInfo.vue'
 import News from '@/data/fukui_news.json'
@@ -84,6 +86,7 @@ export default Vue.extend({
     PageHeader,
     BreakingNews,
     FukuiNews,
+    FukuiPaperNews,
     WhatsNew,
     WhatsNewJapan,
     StaticInfo,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -15,8 +15,10 @@
     <breaking-news class="mb-4" :items="BreakingItems" />
     <fukui-paper-news class="mb-4" />
     <fukui-news class="mb-4" />
+    <!--
     <whats-new class="mb-4" :items="newsItems" />
     <whats-new-japan class="mb-4" :items="japanItems" />
+    -->
     <static-info
       class="mb-4"
       :url="localePath('/flow')"
@@ -43,8 +45,8 @@ import { MetaInfo } from 'vue-meta'
 import PageHeader from '@/components/PageHeader.vue'
 // 速報
 import BreakingNews from '@/components/BreakingNews.vue'
-import WhatsNew from '@/components/WhatsNew.vue'
-import WhatsNewJapan from '@/components/WhatsNewJapan.vue'
+// import WhatsNew from '@/components/WhatsNew.vue'
+// import WhatsNewJapan from '@/components/WhatsNewJapan.vue'
 import FukuiPaperNews from '@/components/FukuiPaperNews.vue'
 import FukuiNews from '@/components/FukuiNews.vue'
 import StaticInfo from '@/components/StaticInfo.vue'
@@ -87,8 +89,8 @@ export default Vue.extend({
     BreakingNews,
     FukuiNews,
     FukuiPaperNews,
-    WhatsNew,
-    WhatsNewJapan,
+    // WhatsNew,
+    // WhatsNewJapan,
     StaticInfo,
     ConfirmedCasesNumberCard,
     ConfirmedCasesDetailsCard,


### PR DESCRIPTION
## 目的
- 感染動向の情報鮮度は福井県の新着情報より福井新聞社の方が良いため、RSSモジュールを追加したい

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #96 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- RSSフィードの最新3件をトップページで表示
- UIは他のお知らせモジュールと同一
- 一旦リリースし、福井県のRSSフィードを含めてあとでUI改善を行いたい

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/14051784/78466175-27a22380-7739-11ea-8186-cdf232c03ba5.png)