### PR TITLE
ソースデータのリンクを修正

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -7,9 +7,7 @@
       :chart-option="{}"
       :date="Patients.date"
       :info="sumInfoOfPatients"
-      :url="
-        'https://www.pref.fukui.lg.jp/doc/kenkou/kansensyo-yobousessyu/corona.html'
-      "
+      :url="'https://www.pref.fukui.lg.jp/doc/toukei-jouhou/covid-19.html'"
     />
   </v-col>
 </template>

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -7,9 +7,7 @@
       :chart-data="patientsGraph"
       :date="patientsSummaryDate"
       :unit="$t('人')"
-      :url="
-        'https://www.pref.fukui.lg.jp/doc/kenkou/kansensyo-yobousessyu/corona.html'
-      "
+      :url="'https://www.pref.fukui.lg.jp/doc/toukei-jouhou/covid-19.html'"
     />
   </v-col>
 </template>


### PR DESCRIPTION
福井県の新型コロナウイルス オープンデータのページへ変更

## 👏 解決する issue / Resolved Issues
- close #150

## 📝 関連する issue / Related Issues
- #126

## ⛏ 変更内容 / Details of Changes
- ソースデータのリンク先を福井県 新型コロナウイルスオープンデータのページへ変更