### PR TITLE
Shift-JIS変換を無効化

### DIFF
--- a/covid19_fukui/csv2json.js
+++ b/covid19_fukui/csv2json.js
@@ -13,8 +13,9 @@ const iconv = require('iconv-lite')
 
 /**
  * Shift-JISフラグ
+ * falseの場合はUTF-8として処理
  */
-const ISSHIFTJIS = true
+const ISSHIFTJIS = false
 
 /**
  * 病床数


### PR DESCRIPTION
ファイルをUTF-8としてするように

## 📝 関連する issue / Related Issues
- #126
- #134 

## ⛏ 変更内容 / Details of Changes
- スクレイピングスクリプトが取得するcsvファイルをUTF-8として処理するように変更
    - Shift-JISからの変換をしないようにした