### PR TITLE
JSONの更新時、重複するPRの削除・複数のブランチの指定機能を追加

### DIFF
--- a/.github/workflows/push_fukui_data.yml
+++ b/.github/workflows/push_fukui_data.yml
@@ -14,15 +14,41 @@ jobs:
         id: metadatas
         uses: actions/github-script@0.9.0
         with:
-          update-push-branch: ${{ secrets.SCHEDULED_UPDATE_PUSH_BRANCH }}
+          secondary-base-branch: ${{ secrets.SECONDARY_BASE_BRANCH }}
+          secondary-alt-base-branches: ${{ secrets.SECONDARY_ALT_BASE_BRANCHES }}
           script: |
             console.log(context)
 
-            const baseBranch = context.payload.client_payload != null && typeof context.payload.client_payload.base_branch === 'string' && context.payload.client_payload.base_branch.length > 1
-              ? context.payload.client_payload.base_branch : core.getInput('update-push-branch') || context.payload.repository.default_branch.replace('refs/heads/', '')
+            const defaultBaseBranch = context.payload.repository.default_branch.replace('refs/heads/', '')
 
-            core.setOutput('head-branch', 'update_data/updatejson')
+            const owner = context.payload.repository.owner.login
+            const repo = context.payload.repository.name
+
+            const clientPayloadHasBaseBranch = context.payload.client_payload != null && typeof context.payload.client_payload.base_branch === 'string' && context.payload.client_payload.base_branch.length > 1
+            const inputHasBaseBranch = core.getInput('secondary-base-branch') !== ''
+
+            let baseBranch = ''
+            let altBaseBranches = []
+            if (clientPayloadHasBaseBranch) {
+              baseBranch = context.payload.client_payload.base_branch
+
+              if (Array.isArray(context.payload.client_payload.alt_base_branches)) {
+                altBaseBranches.push(...context.payload.client_payload.alt_base_branches.filter(branch => branch !== ''))
+              }
+            } else if (inputHasBaseBranch) {
+              baseBranch = core.getInput('secondary-base-branch')
+              altBaseBranches = core.getInput('secondary-alt-base-branches').split(' ').filter(branch => branch !== '')
+            } else {
+              baseBranch = defaultBaseBranch
+            }
+
+            const headBranch = `update_data/updatejson_for/${baseBranch}`
+
+            console.log(JSON.stringify({ headBranch, baseBranch, altBaseBranches }))
+
+            core.setOutput('head-branch', headBranch)
             core.setOutput('base-branch', baseBranch)
+            core.setOutput('alt-base-branches', JSON.stringify(altBaseBranches))
             core.setOutput('current-date', (new Date).toString())
 
       - name: Gitを設定
@@ -52,24 +78,75 @@ jobs:
           BRANCH_NAME: ${{ steps.metadatas.outputs.head-branch }}
         run: |
           git switch -c $BRANCH_NAME
-          git push -f -u origin $BRANCH_NAME
 
       - name: コミット
         run: |
           git add .
           git commit -m "[Auto] データを更新 ${{ steps.metadatas.outputs.current-date }}"
+      
+      - name: 重複しているPRを削除
+        uses: actions/github-script@0.9.0
+        id: closed-pulls
+        with:
+          script: |
+            const owner = context.payload.repository.owner.login
+            const repo = context.payload.repository.name
+            const head = '${{ steps.metadatas.outputs.head-branch }}'
+
+            // 重複しているかもしれないPRを取得
+            const duplicatePulls = (await github.pulls.list({
+              owner,
+              repo,
+              head: `${owner}:${head}`,
+              status: 'open',
+            })).data
+
+            const closedPulls = {}
+            for await (pull of duplicatePulls) {
+              await github.pulls.update({
+                owner,
+                repo,
+                pull_number: pull.number,
+                state: 'closed',
+              })
+              closedPulls[pull.base.ref] = pull.number
+            }
+
+            core.setOutput('number-with-branch', JSON.stringify(closedPulls))
 
       - name: プッシュ
-        run: git push
+        run: git push -fu origin '${{ steps.metadatas.outputs.head-branch }}'
 
       - name: Pull request を作成
         uses: actions/github-script@0.9.0
         with:
+          closed-pulls: ${{ steps.closed-pulls.outputs.number-with-branch }}
+          alt-base-branches: ${{ steps.metadatas.outputs.alt-base-branches }}
           script: |
-            github.pulls.create({
-              owner: context.payload.repository.owner.login,
-              repo: context.payload.repository.name,
-              title: '[Auto]データ更新 ${{ steps.metadatas.outputs.current-date }}',
-              head: '${{ steps.metadatas.outputs.head-branch }}',
-              base: '${{ steps.metadatas.outputs.base-branch }}',
-            })
+            const closedPulls = JSON.parse(core.getInput('closed-pulls'), { required: true })
+            const altBaseBranches = JSON.parse(core.getInput('alt-base-branches'), { required: true })
+
+            const owner = context.payload.repository.owner.login
+            const repo = context.payload.repository.name
+            const title = '[Auto]データ更新 ${{ steps.metadatas.outputs.current-date }}'
+            const head = '${{ steps.metadatas.outputs.head-branch }}'
+            const baseBranches = ['${{ steps.metadatas.outputs.base-branch }}', ...altBaseBranches]
+
+            for await (base of baseBranches) {
+              const newPrData = (await github.pulls.create({
+                owner,
+                repo,
+                title,
+                head,
+                base,
+              })).data
+
+              if (closedPulls[base] != null) {
+                await github.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: closedPulls[base],
+                  body: `Superseded by #${newPrData.number}.`,
+                })
+              }
+            }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- #176
- #177

## ~~📝 関連する issue / Related Issues~~

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- JSONの更新時、重複するPRを削除するようにしました
- PRの作成に関して、複数のブランチを指定できるようになりました
  - 例: `/updatejson nomu_production nomu_development`
  - Slackのコマンドの1番目の引数が作成元のブランチに、
  - 2番目以降の引数で指定されたブランチは、1番目の引数のブランチが親となります

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
こんな Pull Request が作成されます→ https://github.com/satackey/covid19-fukui/pull/43
