### PR TITLE
最新のお知らせ(福井県内)カードをトップページから除去

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,10 +14,8 @@
     </div>
     <breaking-news class="mb-4" :items="BreakingItems" />
     <fukui-paper-news class="mb-4" />
-    <!--
-    <fukui-news class="mb-4" />
-    -->
-    <whats-new class="mb-4" :items="newsItems" />
+    <!-- <fukui-news class="mb-4" />
+    <whats-new class="mb-4" :items="newsItems" /> -->
     <whats-new-japan class="mb-4" :items="japanItems" />
     <static-info
       class="mb-4"
@@ -46,7 +44,7 @@ import { MetaInfo } from 'vue-meta'
 import PageHeader from '@/components/PageHeader.vue'
 // 速報
 import BreakingNews from '@/components/BreakingNews.vue'
-import WhatsNew from '@/components/WhatsNew.vue'
+// import WhatsNew from '@/components/WhatsNew.vue'
 import WhatsNewJapan from '@/components/WhatsNewJapan.vue'
 import FukuiPaperNews from '@/components/FukuiPaperNews.vue'
 // import FukuiNews from '@/components/FukuiNews.vue'
@@ -96,7 +94,7 @@ export default Vue.extend({
     BreakingNews,
     // FukuiNews,
     FukuiPaperNews,
-    WhatsNew,
+    // WhatsNew,
     WhatsNewJapan,
     StaticInfo,
     ConfirmedCasesNumberCard,


### PR DESCRIPTION
サイドバーにはリンクが残っている

## 👏 解決する issue / Resolved Issues
- close #209

## 📝 関連する issue / Related Issues
- #96 

## ⛏ 変更内容 / Details of Changes
- トップページから「最新のお知らせ(福井県内)」カードを除去

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/17569894/79066500-51d48200-7cf3-11ea-92d1-e0f2c62bf56d.png)
