### PR TITLE
速報カードのデータをお知らせからとってくるように変更

### DIFF
--- a/components/BreakingNews.vue
+++ b/components/BreakingNews.vue
@@ -10,13 +10,34 @@
       >
     </h2>
     <ul class="BreakingNews-list">
-      <h3 class="breaking-content" />
-      <li v-for="(item, i) in items" :key="i" class="BreakingNews-list-item">
-        <time
-          class="BreakingNews-list-item-anchor-time px-2"
-          v-html="item.date"
-        />
-        <p class="BreakingNews-list-item-anchor-link" v-html="item.text" />
+      <li
+        v-for="(item, i) in items.slice(0, 3)"
+        :key="i"
+        class="BreakingNews-list-item"
+      >
+        <a
+          ref="noopener"
+          class="BreakingNews-list-item-anchor"
+          :href="item.url"
+          target="_blank"
+        >
+          <time
+            class="BreakingNews-list-item-anchor-time px-2"
+            :datetime="formattedDate(item.date)"
+          >
+            {{ item.date }}
+          </time>
+          <span class="BreakingNews-list-item-anchor-link">
+            {{ item.text }}
+            <v-icon
+              v-if="!isInternalLink(item.url)"
+              class="BreakingNews-item-ExternalLinkIcon"
+              size="12"
+            >
+              mdi-open-in-new
+            </v-icon>
+          </span>
+        </a>
       </li>
     </ul>
   </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,7 +12,7 @@
         <span>{{ $t('注釈') }} </span>
       </div>
     </div>
-    <breaking-news class="mb-4" :items="BreakingItems" />
+    <breaking-news class="mb-4" :items="newsItems" />
     <fukui-paper-news class="mb-4" />
     <!-- <fukui-news class="mb-4" />
     <whats-new class="mb-4" :items="newsItems" /> -->


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #224

## ~~📝 関連する issue / Related Issues~~

## ⛏ 変更内容 / Details of Changes
- 速報カードをお知らせ(県内)カードと同様に3件のデータを表示するように変更
- 速報カードに渡すデータをお知らせ(県内)のデータに変更

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/17569894/79091073-d3c1bb00-7d86-11ea-88bc-ff1166b9d17c.png)