### PR TITLE
入院患者数の推移を表示するカードを追加

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -55,7 +55,7 @@ import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
 import DateSelectSlider from '@/components/DateSelectSlider.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
-import { single as color } from '@/utils/colors'
+import { plusMinus as color } from '@/utils/colors'
 
 type Data = {
   dataKind: 'transition' | 'cumulative'
@@ -79,7 +79,7 @@ type Computed = {
     datasets: {
       label: 'transition' | 'cumulative'
       data: number[]
-      backgroundColor: string
+      backgroundColor: string[]
       borderWidth: number
     }[]
   }
@@ -218,7 +218,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               data: this.chartData.map(d => {
                 return d.transition
               }),
-              backgroundColor: color,
+              backgroundColor: this.chartData.map(d => {
+                return d.transition >= 0 ? color[0] : color[1]
+              }),
               borderWidth: 0
             }
           ]
@@ -232,7 +234,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             data: this.chartData.map(d => {
               return d.cumulative
             }),
-            backgroundColor: color,
+            backgroundColor: this.chartData.map(d => {
+              return d.cumulative >= 0 ? color[0] : color[1]
+            }),
             borderWidth: 0
           }
         ]

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -3,7 +3,7 @@
     <template v-slot:description>
       <slot name="description" />
     </template>
-    <template v-slot:button>
+    <template v-if="isEnableButton" v-slot:button>
       <data-selector
         v-model="dataKind"
         :target-id="chartId"
@@ -114,6 +114,8 @@ type Props = {
   chartId: string
   chartData: GraphDataType[]
   transitionType: string
+  isEnableButton: boolean
+  forceDataKind: string
   date: string
   unit: string
   url: string
@@ -153,6 +155,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: Array,
       default: () => []
     },
+    isEnableButton: {
+      type: Boolean,
+      default: true
+    },
+    forceDataKind: {
+      type: String,
+      default: ''
+    },
     transitionType: {
       type: String,
       default: 'daily'
@@ -187,6 +197,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
     displayInfo() {
+      if (this.forceDataKind !== '')
+        this.dataKind =
+          this.forceDataKind === 'transition' ? 'transition' : 'cumulative'
       if (this.dataKind === 'transition') {
         return {
           lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -130,7 +130,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     this.canvas = process.browser
     this.sliderUpdate([0, this.sliderMax])
   },
-  components: { DataView, DataSelector, DateSelectSlider, DataViewBasicInfoPanel },
+  components: {
+    DataView,
+    DataSelector,
+    DateSelectSlider,
+    DataViewBasicInfoPanel
+  },
   props: {
     title: {
       type: String,
@@ -352,7 +357,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         return 1
       }
       return this.chartData.length - 1
-    },
+    }
   },
   methods: {
     formatDayBeforeRatio(dayBeforeRatio: number): string {

--- a/components/cards/HospitalizedPatientsCard.vue
+++ b/components/cards/HospitalizedPatientsCard.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-col cols="12" md="6" class="DataCard">
+    <time-bar-chart
+      :title="$t('入院患者数')"
+      :title-id="'number-of-confirmed-cases'"
+      :chart-id="'time-bar-chart-patients'"
+      :chart-data="hospitalizedPatientsGraph"
+      :date="updatedAt"
+      :unit="$t('人')"
+      :url="'https://www.pref.fukui.lg.jp/doc/toukei-jouhou/covid-19.html'"
+    />
+  </v-col>
+</template>
+
+<script>
+import HospitalizedPatients from '@/data/hospitalized_patients.json'
+import formatGraph from '@/utils/formatGraph'
+import { getCommonStyleDateString } from '@/utils/formatDate'
+import TimeBarChart from '@/components/TimeBarChart.vue'
+
+export default {
+  components: {
+    TimeBarChart
+  },
+  data() {
+    return {
+      updatedAt: getCommonStyleDateString(HospitalizedPatients.date),
+      // 感染者数グラフ
+      hospitalizedPatientsGraph: formatGraph(HospitalizedPatients.data)
+    }
+  }
+}
+</script>

--- a/components/cards/HospitalizedPatientsCard.vue
+++ b/components/cards/HospitalizedPatientsCard.vue
@@ -2,8 +2,8 @@
   <v-col cols="12" md="6" class="DataCard">
     <time-bar-chart
       :title="$t('入院患者数')"
-      :title-id="'number-of-confirmed-cases'"
-      :chart-id="'time-bar-chart-patients'"
+      :title-id="'number-of-hospitalized-patients'"
+      :chart-id="'time-bar-chart-hospitalized-patients'"
       :chart-data="hospitalizedPatientsGraph"
       :date="updatedAt"
       :unit="$t('人')"

--- a/components/cards/HospitalizedPatientsCard.vue
+++ b/components/cards/HospitalizedPatientsCard.vue
@@ -5,6 +5,8 @@
       :title-id="'number-of-hospitalized-patients'"
       :chart-id="'time-bar-chart-hospitalized-patients'"
       :chart-data="hospitalizedPatientsGraph"
+      :is-enable-button="false"
+      :force-data-kind="'cumulative'"
       :date="updatedAt"
       :unit="$t('人')"
       :url="'https://www.pref.fukui.lg.jp/doc/toukei-jouhou/covid-19.html'"

--- a/components/cards/HospitalizedPatientsCard.vue
+++ b/components/cards/HospitalizedPatientsCard.vue
@@ -8,7 +8,31 @@
       :date="updatedAt"
       :unit="$t('人')"
       :url="'https://www.pref.fukui.lg.jp/doc/toukei-jouhou/covid-19.html'"
-    />
+    >
+      <template v-slot:description>
+        <ul>
+          <li>
+            {{ $t('(注)１日あたりの入退院件数を表しています') }} <br />
+            {{
+              $t(
+                '(注)入退院件数 = 入院件数 - 退院件数 - 死亡件数 と計算しています'
+              )
+            }}
+            <br />
+            {{
+              $t(
+                '(注)青グラフの場合、入院者数が１日の退院者数を上回っている。'
+              )
+            }}<br />
+            {{
+              $t(
+                '(注)赤グラフの場合、退院者数が１日の入院者数を上回っていることを示しています'
+              )
+            }}
+          </li>
+        </ul>
+      </template>
+    </time-bar-chart>
   </v-col>
 </template>
 

--- a/covid19_fukui/csv2json.js
+++ b/covid19_fukui/csv2json.js
@@ -81,69 +81,73 @@ const files = {
   inspectionPersons: 'inspection_persons.json', // 検査実施人数
   inspectionSummary: 'inspection_summary.json', // 検査陽性者の状況
   patientsSummary: 'patients_summary.json', // 陽性患者数
-  patients: 'patients.json' // 陽性患者の属性
+  patients: 'patients.json', // 陽性患者の属性
+  hospitaliedPatients: 'hospitalized_patients.json' // 入院患者数
 }
 
 const main = async () => {
   try{
-  // オープンデータ取得
-  for (const source of openDataSource) {
-    const csv = await getCSV(source.url)
-    const json = await csv2json().fromString(csv)
-    source.json = json
-  }
-  // ニュースデータ取得
-  const newsJson = (await axios.get(newsURL)).data
-  const breakingNewsJson = newsJson.breaking_news
-  const fukuiNewsJson = newsJson.fukui_news
-  const japanNewsJson = newsJson.japan_news
+    // オープンデータ取得
+    for (const source of openDataSource) {
+      const csv = await getCSV(source.url)
+      const json = await csv2json().fromString(csv)
+      source.json = json
+    }
+    // ニュースデータ取得
+    const newsJson = (await axios.get(newsURL)).data
+    const breakingNewsJson = newsJson.breaking_news
+    const fukuiNewsJson = newsJson.fukui_news
+    const japanNewsJson = newsJson.japan_news
 
-  // オープンデータ
-  const today = new Date()
-  today.setHours(today.getHours() + 9)
-  const jsonObjectBase = {
-    date: dateFormat.format(today, 'yyyy/MM/dd hh:mm')
-  }
-  // 各JSONを作成
-  const contactsJson = Object.assign({}, jsonObjectBase)
-  const hospitalBedsJson = Object.assign({}, jsonObjectBase)
-  const inspectionPersonsJson = Object.assign({}, jsonObjectBase)
-  const inspectionSummaryJson = Object.assign({}, jsonObjectBase)
-  const patientsJson = Object.assign({}, jsonObjectBase)
-  const patientsSummaryJson = Object.assign({}, jsonObjectBase)
-  // LINQの設定
-  const linq = Enumerable.from(openDataSource)
-  // 各JSONの処理
-  contacts(linq.where(x => x.name === 'call_center').first().json, contactsJson)
-  hospitalBeds(
-    linq.where(x => x.name === 'discharge').first().json,
-    hospitalBedsJson
-  )
-  inspectionPersons(
-    linq.where(x => x.name === 'test_count').first().json,
-    inspectionPersonsJson
-  )
-  inspectionSummary(
-    linq.where(x => x.name === 'patients').first().json,
-    linq.where(x => x.name === 'discharge').first().json,
-    inspectionSummaryJson
-  )
-  patients(linq.where(x => x.name === 'patients').first().json, patientsJson)
-  patientsSummary(
-    linq.where(x => x.name === 'patients').first().json,
-    patientsSummaryJson
-  )
+    // オープンデータ
+    const today = new Date()
+    today.setHours(today.getHours() + 9)
+    const jsonObjectBase = {
+      date: dateFormat.format(today, 'yyyy/MM/dd hh:mm')
+    }
+    // 各JSONを作成
+    const contactsJson = Object.assign({}, jsonObjectBase)
+    const hospitalBedsJson = Object.assign({}, jsonObjectBase)
+    const inspectionPersonsJson = Object.assign({}, jsonObjectBase)
+    const inspectionSummaryJson = Object.assign({}, jsonObjectBase)
+    const patientsJson = Object.assign({}, jsonObjectBase)
+    const patientsSummaryJson = Object.assign({}, jsonObjectBase)
+    const hospitalizedPatientsJson = Object.assign({}, jsonObjectBase)
+    // LINQの設定
+    const linq = Enumerable.from(openDataSource)
+    // 各JSONの処理
+    contacts(linq.where(x => x.name === 'call_center').first().json, contactsJson)
+    hospitalBeds(
+      linq.where(x => x.name === 'discharge').first().json,
+      hospitalBedsJson
+    )
+    inspectionPersons(
+      linq.where(x => x.name === 'test_count').first().json,
+      inspectionPersonsJson
+    )
+    inspectionSummary(
+      linq.where(x => x.name === 'patients').first().json,
+      linq.where(x => x.name === 'discharge').first().json,
+      inspectionSummaryJson
+    )
+    patients(linq.where(x => x.name === 'patients').first().json, patientsJson)
+    patientsSummary(
+      linq.where(x => x.name === 'patients').first().json,
+      patientsSummaryJson
+    )
+    hospitalizedPatients(linq.where(x => x.name === 'discharge').first().json, hospitalizedPatientsJson)
 
-  // 書き出し
-  writeFile(breakingNewsJson, files.breakingNews)
-  writeFile(fukuiNewsJson, files.fukuiNews)
-  writeFile(japanNewsJson, files.japanNews)
-  writeFile(contactsJson, files.contacts)
-  writeFile(hospitalBedsJson, files.hospitalBeds)
-  writeFile(inspectionPersonsJson, files.inspectionPersons)
-  writeFile(inspectionSummaryJson, files.inspectionSummary)
-  writeFile(patientsJson, files.patients)
-  writeFile(patientsSummaryJson, files.patientsSummary)
+    // 書き出し
+    writeFile(breakingNewsJson, files.breakingNews)
+    writeFile(fukuiNewsJson, files.fukuiNews)
+    writeFile(japanNewsJson, files.japanNews)
+    writeFile(contactsJson, files.contacts)
+    writeFile(hospitalBedsJson, files.hospitalBeds)
+    writeFile(inspectionPersonsJson, files.inspectionPersons)
+    writeFile(inspectionSummaryJson, files.inspectionSummary)
+    writeFile(patientsJson, files.patients)
+    writeFile(patientsSummaryJson, files.patientsSummary)
+    writeFile(hospitalizedPatientsJson, files.hospitaliedPatients)
   } catch(e) {
     console.error(e)
     process.exit(1)
@@ -193,16 +197,20 @@ function writeFile(json, fileName) {
  */
 function isUpdateJSON(oldJSON, newJSON) {
   // newJSONはシャローコピーなのでディープコピーを作成
-  const newJSONClone = JSON.parse(JSON.stringify(newJSON) || "null")
+  const newJSONClone = JSON.parse(JSON.stringify(newJSON) || 'null')
   // 各jsonからdateを除去
-  if("date" in oldJSON)
-    delete oldJSON.date
-  if("date" in newJSON)
-    delete newJSONClone.date
-    if("timestamp" in oldJSON)
-    delete oldJSON.timestamp
-    if("timestamp" in newJSON)
-    delete newJSONClone.timestamp
+  if(oldJSON !== null) {
+    if (oldJSON.hasOwnProperty('date'))
+      delete oldJSON.date
+    if (oldJSON.hasOwnProperty('timestamp'))
+      delete oldJSON.timestamp
+  }
+  if(newJSON !== null) {
+    if(newJSON.hasOwnProperty('date'))
+      delete newJSONClone.date
+    if(newJSON.hasOwnProperty('timestamp'))
+      delete newJSONClone.timestamp
+  }
   const oldJSONStr = JSON.stringify(oldJSON)
   const newJSONCloneStr = JSON.stringify(newJSONClone)
   return oldJSONStr !== newJSONCloneStr
@@ -382,6 +390,30 @@ function patientsSummary(json, jsonObject) {
     }
     jsonObject.data.push(newObj)
   }
+}
+
+/**
+ * 日毎の入院患者数をJSONにします
+ * @param {Object} json 元の情報があるJSONオブジェクト
+ * @param {Object} jsonObject 書き出すJSONオブジェクト
+ */
+function hospitalizedPatients(json, jsonObject) {
+  jsonObject.data = []
+  Enumerable.from(json).forEach(row => {
+    const publicationDay = new Date(row.完了_年月日)
+    const publicationDate = dateFormat.format(publicationDay, 'yyyy-MM-dd')
+    const publicationDateString = `${publicationDate}T00:00:00.000+09:00`
+    const positivePatiensNum = parseInt(row.陽性確認_件数)
+    const deadNum = parseInt(row.死亡確認_件数)
+    const dischargeNum = parseInt(row.陰性確認_件数)
+    const hospitalizedNum = positivePatiensNum - deadNum - dischargeNum
+
+    const newObj = {
+      日付: publicationDateString,
+      小計: hospitalizedNum
+    }
+    jsonObject.data.push(newObj)
+  })
 }
 
 const dateFormat = {

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -117,10 +117,10 @@ export default {
         title = this.$t('陽性患者の属性')
         updatedAt = InspectionsSummary.date
         break
-        // case 'number-of-tested':
-        //   title = this.$t('検査実施件数')
-        //   updatedAt = InspectionsSummary.date
-        break
+      // case 'number-of-tested':
+      //   title = this.$t('検査実施件数')
+      //   updatedAt = InspectionsSummary.date
+      // break
       case 'number-of-inspection-persons':
         title = this.$t('検査実施人数')
         updatedAt = InspectionPersons.date
@@ -174,7 +174,7 @@ export default {
   },
   head() {
     const url = 'https://covid19-fukui.com'
-    const timestamp = new Date().getTime()
+    // const timestamp = new Date().getTime()
     const ogpImage = this.$tc('ogp.og:image')
     const description = `${this.updatedAt} | ${this.$t(
       '当サイトは福井県における新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、福井高専生卒の野村弘樹が開設したものです'

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -3,6 +3,9 @@
     <confirmed-cases-details-card
       v-if="this.$route.params.card == 'details-of-confirmed-cases'"
     />
+    <hospitalized-patients-card
+      v-if="this.$route.params.card == 'hospitalized-patients'"
+    />
     <!-- <tested-cases-details-card
       v-else-if="this.$route.params.card == 'details-of-tested-cases'"
     /> -->
@@ -47,6 +50,8 @@
 import InspectionPersons from '@/data/inspection_persons.json'
 // 陽性患者の属性
 import InspectionsSummary from '@/data/inspection_summary.json'
+// 入院患者数
+import HospitalizedPatients from '@/data/hospitalized_patients.json'
 // 感染症病床使用率
 import HospitalBeds from '@/data/hospital_beds.json'
 // 陽性患者数
@@ -61,6 +66,7 @@ import Contacts from '@/data/contacts.json'
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 // import TestedCasesDetailsCard from '@/components/cards/TestedCasesDetailsCard.vue'
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
+import HospitalizedPatientsCard from '@/components/cards/HospitalizedPatientsCard.vue'
 import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
 // import TestedNumåberCard from '@/components/cards/TestedNumberCard.vue'
 import InspectionPersonsNumberCard from '@/components/cards/InspectionPersonsNumberCard.vue'
@@ -83,6 +89,7 @@ import MaskInventoryCard from '@/components/cards/MaskInventoryCard.vue'
 export default {
   components: {
     ConfirmedCasesDetailsCard,
+    HospitalizedPatientsCard,
     // TestedCasesDetailsCard,
     ConfirmedCasesNumberCard,
     ConfirmedCasesAttributesCard,
@@ -109,6 +116,10 @@ export default {
       //   title = this.$t('検査実施状況')
       //   updatedAt = InspectionsSummary.date
       //   break
+      case 'hospitalied-patients':
+        title = this.$t('入院患者数')
+        updatedAt = HospitalizedPatients.date
+        break
       case 'number-of-confirmed-cases':
         title = this.$t('陽性患者数')
         updatedAt = PatientsSummary.date

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -91,7 +91,7 @@ export default {
     HospitalBedsNumberCard,
     InformationNumberCard,
     EachSexAgeNumberPositiveCard,
-    MaskInventoryCard,
+    MaskInventoryCard
     // ConsultationDeskReportsNumberCard,
     // MetroCard,
     // AgencyCard,
@@ -117,9 +117,9 @@ export default {
         title = this.$t('陽性患者の属性')
         updatedAt = InspectionsSummary.date
         break
-      // case 'number-of-tested':
-      //   title = this.$t('検査実施件数')
-      //   updatedAt = InspectionsSummary.date
+        // case 'number-of-tested':
+        //   title = this.$t('検査実施件数')
+        //   updatedAt = InspectionsSummary.date
         break
       case 'number-of-inspection-persons':
         title = this.$t('検査実施人数')
@@ -154,7 +154,7 @@ export default {
         title = this.$t('コールセンターお問合せ件数')
         updatedAt = Contacts.date
         break
-      
+
       case 'each-sex-age-number-positive':
         title = this.$t('年代別の陽性患者数')
         updatedAt = PatientsSummary.date

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,6 +40,7 @@
     <v-row class="DataBlock">
       <!-- <youtube-card /> -->
       <confirmed-cases-number-card />
+      <hospitalized-patients-card />
       <confirmed-cases-details-card />
       <each-sex-age-number-positive-card />
       <inspection-persons-number-card />
@@ -66,6 +67,8 @@ import JapanNews from '@/data/japan_news.json'
 import BreakingNewsData from '@/data/breaking_news.json'
 // 陽性患者数
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
+// 入院患者数
+import HospitalizedPatientsCard from '@/components/cards/HospitalizedPatientsCard.vue'
 // 陽性患者の属性
 import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
 // 検査陽性者の状況
@@ -118,6 +121,7 @@ export default Vue.extend({
     WhatsNewJapan,
     StaticInfo,
     ConfirmedCasesNumberCard,
+    HospitalizedPatientsCard,
     ConfirmedCasesDetailsCard,
     InspectionPersonsNumberCard,
     // TestedCasesDetailsCard,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,9 @@
       :url="localePath('/mask')"
       target="_blank"
       :text="
-        $t('ゲンキーで販売されている県あっせんマスクについての情報はこちらからご確認いただけます')
+        $t(
+          'ゲンキーで販売されている県あっせんマスクについての情報はこちらからご確認いただけます'
+        )
       "
       :btn-text="$t('マスク情報へ')"
     />
@@ -101,7 +103,10 @@ import EachSexAgeNumberPositiveCard from '@/components/cards/EachSexAgeNumberPos
 // import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDeskReportsNumberCard.vue'
 // import MetroCard from '@/components/cards/MetroCard.vue'
 // import AgencyCard from '@/components/cards/AgencyCard.vue'
-import { convertDatetimeToISO8601Format, getCommonStyleDateString } from '@/utils/formatDate'
+import {
+  convertDatetimeToISO8601Format,
+  getCommonStyleDateString
+} from '@/utils/formatDate'
 
 export default Vue.extend({
   components: {

--- a/utils/colors.ts
+++ b/utils/colors.ts
@@ -2,3 +2,4 @@ export const single: string = '#003580'
 export const double: string[] = ['#003580', '#006aff']
 export const triple: string[] = ['#003580', '#006aff', '#66a6ff']
 export const quadruple: string[] = ['#003580', '#006aff', '#66a6ff', '#99c3ff']
+export const plusMinus: string[] = ['#003580', '#B30F3A']


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #937

## ⛏ 変更内容 / Details of Changes
- 入院患者数の推移をJSONに生成するようスクリプトを変更
- 入院患者数の推移をグラフとして表示するカードを追加
- 一部lintの対応

## 対応中の内容 / Details of Woking in Progress
- ~~グラフデータがマイナスの場合に赤色にする~~
- 注釈などの文章の調整
- 配置の調整

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/17569894/80682395-6095a400-8afd-11ea-8d61-c39383de6875.png)
![image](https://user-images.githubusercontent.com/17569894/80681105-f7149600-8afa-11ea-9e1b-c855017acf62.png)
