### PR TITLE
感染症病床使用率カードを移動

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -44,9 +44,9 @@
       <confirmed-cases-details-card />
       <each-sex-age-number-positive-card />
       <inspection-persons-number-card />
+      <hospital-beds-number-card />
       <confirmed-cases-attributes-card />
       <information-number-card />
-      <hospital-beds-number-card />
     </v-row>
   </div>
 </template>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1149

## ~~📝 関連する issue / Related Issues~~

## ⛏ 変更内容 / Details of Changes
- 感染症病床使用率カードを陽性患者の属性カードより上に移動

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/17569894/81554732-46dc4280-93c2-11ea-9b19-99052be3da8f.png)