### PR TITLE
入院患者数カードが単体で呼ばれた時の定義を修正

### DIFF
--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -116,7 +116,7 @@ export default {
       //   title = this.$t('検査実施状況')
       //   updatedAt = InspectionsSummary.date
       //   break
-      case 'hospitalied-patients':
+      case 'number-of-hospitalized-patients':
         title = this.$t('入院患者数')
         updatedAt = HospitalizedPatients.date
         break


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1179 

~~## 📝 関連する issue / Related Issues~~

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 入院患者数カードが単体で呼ばれた時の名前に不一致があったので修正した

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
- 修正前
<img width="973" alt="image" src="https://user-images.githubusercontent.com/34150349/81561751-a3ddf580-93ce-11ea-9c65-a7148fb32908.png">

- 修正後
<img width="975" alt="image" src="https://user-images.githubusercontent.com/34150349/81561916-ef909f00-93ce-11ea-9858-8dc585b7bad9.png">
