### PR TITLE
マスクに関する情報ページを無効化

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -144,12 +144,12 @@ export default Vue.extend({
           title: this.$t('新型コロナウイルス感染症が心配な方はこちら'),
           link: this.localePath('/flow')
         },
-        {
-          icon: 'SurgicalMaskIcon',
-          title: this.$t('県あっせんマスクについて'),
-          link: this.localePath('/mask'),
-          divider: true
-        },
+        // {
+        //   icon: 'SurgicalMaskIcon',
+        //   title: this.$t('県あっせんマスクについて'),
+        //   link: this.localePath('/mask'),
+        //   divider: true
+        // },
         {
           icon: 'mdi-information',
           title: this.$t('福井新聞社の速報（RSS）'),

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,7 +12,7 @@
         <span>{{ $t('注釈') }} </span>
       </div>
     </div>
-    <static-info
+    <!-- <static-info
       class="mb-4"
       :url="localePath('/mask')"
       target="_blank"
@@ -22,7 +22,7 @@
         )
       "
       :btn-text="$t('マスク情報へ')"
-    />
+    /> -->
     <breaking-news class="mb-4" :items="newsItems" />
     <fukui-paper-news class="mb-4" />
     <!-- <fukui-news class="mb-4" />


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2222

## ~~📝 関連する issue / Related Issues~~

## ⛏ 変更内容 / Details of Changes
- サイドバーのマスクに関するページへのリンクを解除

## 📸 スクリーンショット / Screenshots
<img width="1307" alt="image" src="https://user-images.githubusercontent.com/17569894/87239488-badea980-c44a-11ea-850f-1e3520f4f8e8.png">
