### PR TITLE
検査実施人数カードを復活

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -31,10 +31,10 @@
       <hospitalized-patients-card />
       <confirmed-cases-details-card />
       <each-sex-age-number-positive-card />
-      <!-- <inspection-persons-number-card /> -->
+      <inspection-persons-number-card />
       <hospital-beds-number-card />
-      <information-number-card />
       <confirmed-cases-attributes-card />
+      <information-number-card />
     </v-row>
   </div>
 </template>
@@ -64,7 +64,7 @@ import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttri
 // 検査陽性者の状況
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 // 検査実施人数
-// import InspectionPersonsNumberCard from '@/components/cards/InspectionPersonsNumberCard.vue'
+import InspectionPersonsNumberCard from '@/components/cards/InspectionPersonsNumberCard.vue'
 // 病床数
 import HospitalBedsNumberCard from '@/components/cards/HospitalBedsNumberCard.vue'
 // Youtube
@@ -114,7 +114,7 @@ export default Vue.extend({
     ConfirmedCasesNumberCard,
     HospitalizedPatientsCard,
     ConfirmedCasesDetailsCard,
-    // InspectionPersonsNumberCard,
+    InspectionPersonsNumberCard,
     // TestedCasesDetailsCard,
     ConfirmedCasesAttributesCard,
     HospitalBedsNumberCard,


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5421

## 📝 関連する issue / Related Issues
- #4281

## ⛏ 変更内容 / Details of Changes
- トップページに検査実施人数カードを表示するように変更

## 📸 スクリーンショット / Screenshots
![localhost_3000_](https://user-images.githubusercontent.com/17569894/103162599-f3761200-4835-11eb-902e-b2c009e9ff0e.png)
