### PR TITLE
画面の幅が小さいときに陽性患者の属性カードの表示が小さくなる問題を修正

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="6" class="DataCard">
+  <v-col cols="12" md="6" class="DataCard">
     <data-table
       :title="$t('陽性患者の属性')"
       :title-id="'attributes-of-confirmed-cases'"


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #7175 

~~## 📝 関連する issue / Related Issues~~

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 陽性患者の属性カードの幅が画面サイズに合わせて調整されるようにした
 
## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/34150349/115235005-a4414d80-a154-11eb-960f-7c01fa826a2b.png)
![image](https://user-images.githubusercontent.com/34150349/115235094-bf13c200-a154-11eb-8f29-f7878f6a3781.png)
